### PR TITLE
Refactor monit_version and add spec test

### DIFF
--- a/lib/facter/monit_version.rb
+++ b/lib/facter/monit_version.rb
@@ -1,11 +1,14 @@
-if Facter::Util::Resolution.which('monit')
-  version = Facter::Util::Resolution.exec('monit -V 2>&1').match(/\d+\.\d+$/).to_s
+# A facter fact to determine the installed version of monit.
 
-  if version
-    Facter.add('monit_version') do
-      setcode do
-        version
-      end
+module Facter::Util::MonitVersion
+  class << self
+    def get_monit_version
+      monit_version = Facter::Util::Resolution.exec('monit -V 2>&1')
+      monit_version && monit_version.match(/\d+\.\d+$/).to_s
     end
   end
+end
+
+Facter.add(:monit_version) do
+  setcode { Facter::Util::MonitVersion.get_monit_version }
 end

--- a/spec/unit/facter/monit_version_spec.rb
+++ b/spec/unit/facter/monit_version_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'facter/monit_version'
+
+describe 'Facter::Util::MonitVersion (monit_version)' do
+  context 'with monit v5.14 installed' do
+    let(:monit_version) {
+      "This is Monit version 5.14\nCopyright (C) 2001-2015 Tildeslash Ltd. All Rights Reserved."
+    }
+    it 'should return 5.14' do
+      Facter::Util::Resolution.expects(:exec).with('monit -V 2>&1').returns(monit_version)
+      expect(Facter::Util::MonitVersion.get_monit_version).to eq('5.14')
+    end
+  end
+  context 'with monit not installed' do
+    it 'should be nil' do
+      Facter::Util::Resolution.expects(:exec).with('monit -V 2>&1').returns(nil)
+      expect(Facter::Util::MonitVersion.get_monit_version).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Needed refactoring because monit_version was only able to test when monit was actually installed on the testing system. Otherwise we got a "undefined method `value' for nil:NilClass" error message. You can see theses on my first Travis runs [1].

@ghoneycutt **Please check if refactored fact matches your expectations.**

[1] https://travis-ci.org/Phil-Friderici/puppet-monit/builds/93687090
